### PR TITLE
Added BsonDocument and BsonValues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
     jvm {
         compilations.all { kotlinOptions.jvmTarget = "1.8" }
         withJava()
+        tasks.withType<Test> { useJUnitPlatform() }
     }
 
     js(IR) { nodejs {} }
@@ -50,7 +51,15 @@ kotlin {
         val commonMain by getting
         val commonTest by getting { dependencies { implementation(kotlin("test")) } }
         val jvmMain by getting
-        val jvmTest by getting
+        val jvmTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlin:kotlin-reflect:1.7.10")
+                implementation("org.junit.jupiter:junit-jupiter:5.9.0")
+                implementation("org.reflections:reflections:0.10.2")
+                implementation("org.mongodb:bson:4.7.0")
+            }
+        }
 
         val jsMain by getting
         val jsTest by getting
@@ -138,5 +147,7 @@ spotless {
         endWithNewline()
     }
 }
+
+tasks.named("check") { dependsOn(":spotlessApply") }
 
 tasks.named("compileKotlinMetadata") { dependsOn(":spotlessApply") }

--- a/src/commonMain/kotlin/org/kbson/BSONException.kt
+++ b/src/commonMain/kotlin/org/kbson/BSONException.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A general runtime exception raised in BSON processing. */
+open class BSONException(
+    message: String? = null,
+    cause: Throwable? = null,
+    val errorCode: Int? = null
+) : RuntimeException(message, cause) {
+
+    /**
+     * Returns if the error code is set (i.e., not null).
+     *
+     * @return true if the error code is not null.
+     */
+    fun hasErrorCode(): Boolean {
+        return errorCode != null
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonArray.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonArray.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A type-safe representation of the BSON array type. */
+class BsonArray(initial: List<BsonValue> = emptyList()) : BsonValue(), List<BsonValue> {
+    val values: MutableList<BsonValue>
+    init {
+        values = initial.toMutableList()
+    }
+
+    /**
+     * Construct an empty BsonArray with the specified initial capacity.
+     *
+     * @param initialCapacity the initial capacity of the BsonArray
+     * @throws IllegalArgumentException if the specified initial capacity is negative
+     */
+    constructor(initialCapacity: Int) : this(ArrayList<BsonValue>(initialCapacity))
+
+    /** Creates and returns a deep copy of this object */
+    fun clone(): BsonArray {
+        val clonedValues =
+            values.fold(ArrayList<BsonValue>(values.size)) { list, value ->
+                if (value.isArray()) {
+                    list.add(value.asArray().clone())
+                } else if (value.isDocument()) {
+                    list.add(value.asDocument().clone())
+                } else {
+                    list.add(value)
+                }
+                list
+            }
+        return BsonArray(clonedValues)
+    }
+
+    override fun getBsonType(): BsonType {
+        return BsonType.ARRAY
+    }
+
+    override fun contains(element: BsonValue): Boolean {
+        return values.contains(element)
+    }
+
+    override fun containsAll(elements: Collection<BsonValue>): Boolean {
+        return values.containsAll(elements)
+    }
+
+    override fun get(index: Int): BsonValue {
+        return values[index]
+    }
+
+    override fun isEmpty(): Boolean {
+        return values.isEmpty()
+    }
+
+    override fun iterator(): Iterator<BsonValue> {
+        return values.iterator()
+    }
+
+    override fun listIterator(): ListIterator<BsonValue> {
+        return values.listIterator()
+    }
+
+    override fun listIterator(index: Int): ListIterator<BsonValue> {
+        return values.listIterator(index)
+    }
+
+    override fun subList(fromIndex: Int, toIndex: Int): List<BsonValue> {
+        return values.subList(fromIndex, toIndex)
+    }
+
+    override fun lastIndexOf(element: BsonValue): Int {
+        return values.lastIndexOf(element)
+    }
+
+    override fun indexOf(element: BsonValue): Int {
+        return values.indexOf(element)
+    }
+
+    override fun toString(): String {
+        return "BsonArray{values=$values}"
+    }
+
+    override val size: Int
+        get() = values.size
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonArray
+
+        if (values != other.values) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return values.hashCode()
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonBinary.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonBinary.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/**
+ * A representation of the BSON Binary type.
+ *
+ * <p>Note that for performance reasons instances of this class are not immutable, so care should be
+ * taken to only modify the underlying byte array if you know what you're doing, or else make a
+ * defensive copy. </p>
+ */
+class BsonBinary(val type: Byte, val data: ByteArray) : BsonValue() {
+
+    /**
+     * Construct a new instance with the given data and the default sub-type
+     *
+     * @param data the data
+     *
+     * @see org.kbson.multi.BsonBinarySubType.BINARY
+     */
+    constructor(data: ByteArray) : this(BsonBinarySubType.BINARY.value, data)
+
+    /**
+     * Construct a new instance with the given data and binary sub type.
+     *
+     * @param data the data
+     * @param type the binary sub type
+     *
+     * @see org.kbson.multi.BsonBinarySubType.BINARY
+     */
+    constructor(type: BsonBinarySubType, data: ByteArray) : this(type.value, data)
+
+    override fun getBsonType(): BsonType {
+        return BsonType.BINARY
+    }
+
+    override fun toString(): String {
+        return ("BsonBinary{type=$type, data=$data}")
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonBinary
+
+        if (type != other.type) return false
+        if (!data.contentEquals(other.data)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type.toInt()
+        result = 31 * result + data.contentHashCode()
+        return result
+    }
+
+    companion object {
+
+        /** Creates a clone of the BsonBinary */
+        fun clone(from: BsonBinary): BsonBinary {
+            return BsonBinary(from.type, from.data.copyOf())
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonBinarySubType.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonBinarySubType.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** The Binary subtype */
+enum class BsonBinarySubType(val value: Byte) {
+    /** Binary data. */
+    BINARY(0x00.toByte()),
+
+    /** A function. */
+    FUNCTION(0x01.toByte()),
+
+    /** Obsolete binary data subtype (use Binary instead). */
+    OLD_BINARY(0x02.toByte()),
+
+    /** A UUID in a driver dependent legacy byte order. */
+    UUID_LEGACY(0x03.toByte()),
+
+    /** A UUID in standard network byte order. */
+    UUID_STANDARD(0x04.toByte()),
+
+    /** An MD5 hash. */
+    MD5(0x05.toByte()),
+
+    /** Encrypted data. */
+    ENCRYPTED(0x06.toByte()),
+
+    /** Columnar data */
+    COLUMN(0x07.toByte()),
+
+    /** User defined binary data. */
+    USER_DEFINED(0x80.toByte())
+}

--- a/src/commonMain/kotlin/org/kbson/BsonBoolean.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonBoolean.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.jvm.JvmStatic
+
+/** A representation of the BSON Boolean type. */
+class BsonBoolean(val value: Boolean) : BsonValue(), Comparable<BsonBoolean> {
+
+    override fun getBsonType(): BsonType {
+        return BsonType.BOOLEAN
+    }
+
+    override fun compareTo(other: BsonBoolean): Int {
+        return value.compareTo(other.value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonBoolean
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return if (value) 1 else 0
+    }
+
+    override fun toString(): String {
+        return "BsonBoolean(value=$value)"
+    }
+
+    companion object {
+        /** The true value. */
+        val TRUE = BsonBoolean(true)
+
+        /** The false value. */
+        val FALSE = BsonBoolean(false)
+
+        /**
+         * Returns a `BsonBoolean` instance representing the specified `boolean` value.
+         *
+         * @param value a boolean value.
+         * @return @link if `value` is true, [BsonBoolean.FALSE] if `value` is false
+         */
+        @JvmStatic
+        fun valueOf(value: Boolean): BsonBoolean {
+            return if (value) TRUE else FALSE
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonDateTime.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonDateTime.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import org.kbson.ext.getCurrentTimeInMillis
+
+/** A representation of the BSON DateTime type. */
+class BsonDateTime(val value: Long) : BsonValue(), Comparable<BsonDateTime> {
+
+    /** Construct a new instance with 'now' as the current date time */
+    constructor() : this(getCurrentTimeInMillis())
+
+    override fun getBsonType(): BsonType {
+        return BsonType.DATE_TIME
+    }
+
+    override fun compareTo(other: BsonDateTime): Int {
+        return value.compareTo(other.value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonDateTime
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonDateTime(value=$value)"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonDbPointer.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonDbPointer.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/**
+ * Holder for a BSON type DBPointer(0x0c).
+ *
+ * <p>Note: It's deprecated in BSON Specification and present here only for compatibility reasons.
+ */
+class BsonDbPointer(val namespace: String, val id: BsonObjectId) : BsonValue() {
+
+    override fun getBsonType(): BsonType {
+        return BsonType.DB_POINTER
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonDbPointer
+
+        if (namespace != other.namespace) return false
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = namespace.hashCode()
+        result = 31 * result + id.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "BsonDbPointer(namespace='$namespace', id=$id)"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonDecimal128.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonDecimal128.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the BSON Decimal128 type. */
+class BsonDecimal128(val high: Long, val low: Long) : BsonValue() {
+
+    override fun getBsonType(): BsonType {
+        return BsonType.DECIMAL128
+    }
+
+    /**
+     * Returns true if this Decimal128 is negative.
+     *
+     * @return true if this Decimal128 is negative
+     */
+    fun isNegative(): Boolean {
+        return (high and SIGN_BIT_MASK) == SIGN_BIT_MASK
+    }
+
+    /**
+     * Returns true if this Decimal128 is infinite.
+     *
+     * @return true if this Decimal128 is infinite
+     */
+    fun isInfinite(): Boolean {
+        return (high and INFINITY_MASK) == INFINITY_MASK
+    }
+
+    /**
+     * Returns true if this Decimal128 is finite.
+     *
+     * @return true if this Decimal128 is finite
+     */
+    fun isFinite(): Boolean {
+        return !isInfinite()
+    }
+
+    /**
+     * Returns true if this Decimal128 is Not-A-Number (NaN).
+     *
+     * @return true if this Decimal128 is Not-A-Number
+     */
+    fun isNaN(): Boolean {
+        return (high and NaN_MASK) == NaN_MASK
+    }
+
+    override fun toString(): String {
+        return "BsonDecimal128(high=$high, low=$low)"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonDecimal128
+
+        if (high != other.high) return false
+        if (low != other.low) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = high.hashCode()
+        result = 31 * result + low.hashCode()
+        return result
+    }
+
+    companion object {
+        private const val INFINITY_MASK = 0x7800000000000000L
+        private const val NaN_MASK = 0x7c00000000000000L
+        private const val SIGN_BIT_MASK = 1L shl 63
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonDocument.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonDocument.kt
@@ -1,0 +1,705 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A type-safe container for a BSON document. */
+class BsonDocument(map: Map<String, BsonValue> = LinkedHashMap()) :
+    BsonValue(), MutableMap<String, BsonValue> {
+    private val wrapped: LinkedHashMap<String, BsonValue>
+
+    /** Construct an empty document with the specified initial capacity. */
+    constructor(initialCapacity: Int) : this(LinkedHashMap(initialCapacity))
+
+    /** Construct a new instance with a single key value pair */
+    constructor(key: String, value: BsonValue) : this(linkedMapOf(key to value))
+
+    /** Construct a new instance with the given list [BsonElement]s */
+    constructor(
+        bsonElements: List<BsonElement>
+    ) : this(
+        linkedMapOf(
+            *bsonElements
+                .map { bsonElement -> Pair(bsonElement.name, bsonElement.value) }
+                .toTypedArray()))
+
+    /** Construct a new instance with the varargs of key value pairs */
+    constructor(vararg pairs: Pair<String, BsonValue>) : this(linkedMapOf(*pairs))
+
+    init {
+        wrapped = if (map is LinkedHashMap) map else LinkedHashMap(map)
+    }
+
+    override val entries: MutableSet<MutableMap.MutableEntry<String, BsonValue>>
+        get() = wrapped.entries
+    override val keys: MutableSet<String>
+        get() = wrapped.keys
+    override val size: Int
+        get() = wrapped.size
+    override val values: MutableCollection<BsonValue>
+        get() = wrapped.values
+
+    override fun clear() {
+        wrapped.clear()
+    }
+
+    override fun containsKey(key: String): Boolean = wrapped.containsKey(key)
+
+    override fun containsValue(value: BsonValue): Boolean = wrapped.containsValue(value)
+
+    override fun get(key: String): BsonValue? = wrapped[key]
+
+    override fun isEmpty(): Boolean = wrapped.isEmpty()
+    override fun remove(key: String): BsonValue? {
+        return wrapped.remove(key)
+    }
+
+    override fun putAll(from: Map<out String, BsonValue>) {
+        wrapped.putAll(from)
+    }
+
+    override fun put(key: String, value: BsonValue): BsonValue? {
+        return wrapped.put(key, value)
+    }
+
+    override fun getBsonType(): BsonType = BsonType.DOCUMENT
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonDocument
+
+        if (wrapped != other.wrapped) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return wrapped.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonDocument(wrapped=$wrapped)"
+    }
+
+    /** Clone the document */
+    fun clone(): BsonDocument {
+        val clonedValues = HashMap<String, BsonValue>()
+        wrapped.onEach { entry ->
+            if (entry.value.isArray()) {
+                clonedValues[entry.key] = entry.value.asArray().clone()
+            } else if (entry.value.isDocument()) {
+                clonedValues[entry.key] = entry.value.asDocument().clone()
+            } else {
+                clonedValues[entry.key] = entry.value
+            }
+        }
+        return BsonDocument(clonedValues)
+    }
+
+    /**
+     * Gets the first key in the document.
+     *
+     * @return the first key in the document
+     * @throws NoSuchElementException if the document is empty
+     */
+    fun getFirstKey(): String {
+        return keys.iterator().next()
+    }
+
+    /**
+     * Put the given key and value into this document, and return the document.
+     *
+     * @param key the key
+     * @param value the value
+     * @return this
+     */
+    fun append(key: String, value: BsonValue): BsonDocument {
+        put(key, value)
+        return this
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonNull, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonNull, returns false if the document does not
+     * contain the key.
+     */
+    fun isNull(key: String): Boolean {
+        return get(key)?.isNull() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonDocument, returns false if the document does
+     * not contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonDocument, returns false if the document does
+     * not contain the key.
+     */
+    fun isDocument(key: String): Boolean {
+        return get(key)?.isDocument() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonArray, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonArray, returns false if the document does not
+     * contain the key.
+     */
+    fun isArray(key: String): Boolean {
+        return get(key)?.isArray() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonNumber, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonNumber, returns false if the document does not
+     * contain the key.
+     */
+    fun isNumber(key: String): Boolean {
+        return get(key)?.isNumber() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonInt32, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonInt32, returns false if the document does not
+     * contain the key.
+     */
+    fun isInt32(key: String): Boolean {
+        return get(key)?.isInt32() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonInt64, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonInt64, returns false if the document does not
+     * contain the key.
+     */
+    fun isInt64(key: String): Boolean {
+        return get(key)?.isInt64() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonDecimal128, returns false if the document does
+     * not contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonDecimal128, returns false if the document does
+     * not contain the key.
+     * @since 3.4
+     */
+    fun isDecimal128(key: String): Boolean {
+        return get(key)?.isDecimal128() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonDouble, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonDouble, returns false if the document does not
+     * contain the key.
+     */
+    fun isDouble(key: String): Boolean {
+        return get(key)?.isDouble() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonBoolean, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonBoolean, returns false if the document does not
+     * contain the key.
+     */
+    fun isBoolean(key: String): Boolean {
+        return get(key)?.isBoolean() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonString, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonString, returns false if the document does not
+     * contain the key.
+     */
+    fun isString(key: String): Boolean {
+        return get(key)?.isString() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonDateTime, returns false if the document does
+     * not contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonDateTime, returns false if the document does
+     * not contain the key.
+     */
+    fun isDateTime(key: String): Boolean {
+        return get(key)?.isDateTime() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonTimestamp, returns false if the document does
+     * not contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonTimestamp, returns false if the document does
+     * not contain the key.
+     */
+    fun isTimestamp(key: String): Boolean {
+        return get(key)?.isTimestamp() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonObjectId, returns false if the document does
+     * not contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonObjectId, returns false if the document does
+     * not contain the key.
+     */
+    fun isObjectId(key: String): Boolean {
+        return get(key)?.isObjectId() ?: false
+    }
+
+    /**
+     * Returns true if the value of the key is a BsonBinary, returns false if the document does not
+     * contain the key.
+     *
+     * @param key the key
+     * @return true if the value of the key is a BsonBinary, returns false if the document does not
+     * contain the key.
+     */
+    fun isBinary(key: String): Boolean {
+        return get(key)?.isBinary() ?: false
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonValue
+     */
+    operator fun get(key: String, defaultValue: BsonValue): BsonValue {
+        val value = get(key)
+        return value ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonDocument.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonDocument
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getDocument(key: String, defaultValue: BsonDocument): BsonDocument {
+        return get(key)?.asDocument() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonArray.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonArray
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getArray(key: String, defaultValue: BsonArray): BsonArray {
+        return get(key)?.asArray() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonNumber.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonNumber
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getNumber(key: String, defaultValue: BsonNumber): BsonNumber {
+        return get(key)?.asNumber() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonInt32.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonInt32
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getInt32(key: String, defaultValue: BsonInt32): BsonInt32 {
+        return get(key)?.asInt32() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonInt64.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonInt64
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getInt64(key: String, defaultValue: BsonInt64): BsonInt64 {
+        return get(key)?.asInt64() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonDecimal128.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonDecimal128
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     * @since 3.4
+     */
+    fun getDecimal128(key: String, defaultValue: BsonDecimal128): BsonDecimal128 {
+        return get(key)?.asDecimal128() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonDouble.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonDouble
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getDouble(key: String, defaultValue: BsonDouble): BsonDouble {
+        return get(key)?.asDouble() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonBoolean.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonBoolean
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getBoolean(key: String, defaultValue: BsonBoolean): BsonBoolean {
+        return get(key)?.asBoolean() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonString.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonString
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getString(key: String, defaultValue: BsonString): BsonString {
+        return get(key)?.asString() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonDateTime.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonDateTime
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getDateTime(key: String, defaultValue: BsonDateTime): BsonDateTime {
+        return get(key)?.asDateTime() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonTimestamp.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonTimestamp
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getTimestamp(key: String, defaultValue: BsonTimestamp): BsonTimestamp {
+        return get(key)?.asTimestamp() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonObjectId.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonObjectId
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getObjectId(key: String, defaultValue: BsonObjectId): BsonObjectId {
+        return get(key)?.asObjectId() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonBinary.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonBinary
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getBinary(key: String, defaultValue: BsonBinary): BsonBinary {
+        return get(key)?.asBinary() ?: defaultValue
+    }
+
+    /**
+     * If the document does not contain the given key, return the given default value. Otherwise,
+     * gets the value of the key as a BsonRegularExpression.
+     *
+     * @param key the key
+     * @param defaultValue the default value
+     * @return the value of the key as a BsonRegularExpression
+     * @throws org.kbson.BsonInvalidOperationException if the document contains the key but the
+     * value is not of the expected type
+     */
+    fun getRegularExpression(
+        key: String,
+        defaultValue: BsonRegularExpression
+    ): BsonRegularExpression {
+        return get(key)?.asRegularExpression() ?: defaultValue
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonDocument, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonDocument
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not a BsonDocument
+     */
+    fun getDocument(key: String): BsonDocument {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asDocument()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonArray, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonArray
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getArray(key: String): BsonArray {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asArray()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonNumber, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonNumber
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getNumber(key: String): BsonNumber {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asNumber()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonInt32, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonInt32
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getInt32(key: String): BsonInt32 {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asInt32()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonInt64, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonInt64
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getInt64(key: String): BsonInt64 {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asInt64()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonDecimal128, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonDecimal128
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     * @since 3.4
+     */
+    fun getDecimal128(key: String): BsonDecimal128 {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asDecimal128()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonDouble, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonDouble
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getDouble(key: String): BsonDouble {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asDouble()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonBoolean, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonBoolean
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getBoolean(key: String): BsonBoolean {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asBoolean()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonString, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonString
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getString(key: String): BsonString {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asString()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonDateTime, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonDateTime
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getDateTime(key: String): BsonDateTime {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asDateTime()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonTimestamp, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonTimestamp
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getTimestamp(key: String): BsonTimestamp {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asTimestamp()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonObjectId, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonObjectId
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getObjectId(key: String): BsonObjectId {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asObjectId()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonRegularExpression, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonRegularExpression
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getRegularExpression(key: String): BsonRegularExpression {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asRegularExpression()
+    }
+
+    /**
+     * Gets the value of the key if it is a BsonBinary, or throws if not.
+     *
+     * @param key the key
+     * @return the value of the key as a BsonBinary
+     * @throws org.kbson.BsonInvalidOperationException if the document does not contain the key or
+     * the value is not of the expected type
+     */
+    fun getBinary(key: String): BsonBinary {
+        throwIfKeyAbsent(key)
+        return get(key)!!.asBinary()
+    }
+
+    private fun throwIfKeyAbsent(key: Any) {
+        if (!containsKey(key)) {
+            throw BsonInvalidOperationException("Document does not contain key: '$key'")
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonDouble.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonDouble.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the BSON Double type. */
+class BsonDouble(val value: Double) : BsonNumber(), Comparable<BsonDouble> {
+
+    override fun intValue(): Int {
+        return value.toInt()
+    }
+
+    override fun longValue(): Long {
+        return value.toLong()
+    }
+
+    override fun doubleValue(): Double {
+        return value
+    }
+
+    override fun getBsonType(): BsonType {
+        return BsonType.DOUBLE
+    }
+
+    override fun compareTo(other: BsonDouble): Int {
+        return value.compareTo(other.value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonDouble
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonDouble(value=$value)"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonElement.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonElement.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/**
+ * A mapping from a name to a BsonValue.
+ *
+ * @see BsonDocument
+ */
+data class BsonElement(val name: String, val value: BsonValue) {}

--- a/src/commonMain/kotlin/org/kbson/BsonInt32.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonInt32.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the BSON Int32 type. */
+class BsonInt32(val value: Int) : BsonNumber(), Comparable<BsonInt32> {
+
+    override fun intValue(): Int {
+        return value
+    }
+
+    override fun longValue(): Long {
+        return value.toLong()
+    }
+
+    override fun doubleValue(): Double {
+        return value.toDouble()
+    }
+
+    override fun getBsonType(): BsonType {
+        return BsonType.INT32
+    }
+
+    override fun compareTo(other: BsonInt32): Int {
+        return value.compareTo(other.value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonInt32
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value
+    }
+
+    override fun toString(): String {
+        return "BsonInt32(value=$value)"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonInt64.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonInt64.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the BSON Int64 type. */
+class BsonInt64(val value: Long) : BsonNumber(), Comparable<BsonInt64> {
+
+    override fun intValue(): Int {
+        return value.toInt()
+    }
+
+    override fun longValue(): Long {
+        return value
+    }
+
+    override fun doubleValue(): Double {
+        return value.toDouble()
+    }
+
+    override fun getBsonType(): BsonType {
+        return BsonType.INT64
+    }
+
+    override fun compareTo(other: BsonInt64): Int {
+        return value.compareTo(other.value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonInt64
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonInt64(value=$value)"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonInvalidOperationException.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonInvalidOperationException.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** An exception indicating an invalid BSON operation. */
+class BsonInvalidOperationException(message: String? = null, cause: Throwable? = null) :
+    BSONException(message, cause) {}

--- a/src/commonMain/kotlin/org/kbson/BsonJavaScript.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonJavaScript.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** For using the JavaScript Code type. */
+class BsonJavaScript(val code: String) : BsonValue() {
+    override fun getBsonType(): BsonType {
+        return BsonType.JAVASCRIPT
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonJavaScript
+
+        if (code != other.code) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return code.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonJavaScript(code='$code')"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonJavaScriptWithScope.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonJavaScriptWithScope.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the JavaScript Code with Scope BSON type. */
+class BsonJavaScriptWithScope(val code: String, val scope: BsonDocument) : BsonValue() {
+    override fun getBsonType(): BsonType {
+        return BsonType.JAVASCRIPT_WITH_SCOPE
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonJavaScriptWithScope
+
+        if (code != other.code) return false
+        if (scope != other.scope) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = code.hashCode()
+        result = 31 * result + scope.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "BsonJavaScriptWithScope(code='$code', scope=$scope)"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonMaxKey.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonMaxKey.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** Represent the maximum key value regardless of the key's type */
+class BsonMaxKey : BsonValue() {
+    override fun getBsonType(): BsonType {
+        return BsonType.MAX_KEY
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return this::class.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonMaxKey()"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonMinKey.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonMinKey.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** Represent the minimum key value regardless of the key's type */
+class BsonMinKey : BsonValue() {
+    override fun getBsonType(): BsonType {
+        return BsonType.MIN_KEY
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return this::class.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonMinKey()"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonNull.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonNull.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the BSON Null type. */
+class BsonNull : BsonValue() {
+    override fun getBsonType(): BsonType {
+        return BsonType.NULL
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return this::class.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonNull()"
+    }
+
+    companion object {
+        /** A singleton instance of the null value. */
+        val VALUE = BsonNull()
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonNumber.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonNumber.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/**
+ * Base class for the numeric BSON types.
+ *
+ * <p>This class mirrors the functionality provided by the java `Number` class.
+ */
+abstract class BsonNumber : BsonValue() {
+    /**
+     * Returns the value of the specified number as an `int`, which may involve rounding or
+     * truncation.
+     *
+     * @return the numeric value represented by this object after conversion to type `int`.
+     */
+    abstract fun intValue(): Int
+
+    /**
+     * Returns the value of the specified number as an `long`, which may involve rounding or
+     * truncation.
+     *
+     * @return the numeric value represented by this object after conversion to type `long`.
+     */
+    abstract fun longValue(): Long
+
+    /**
+     * Returns the value of the specified number as a `double`, which may involve rounding.
+     *
+     * @return the numeric value represented by this object after conversion to type `double`.
+     */
+    abstract fun doubleValue(): Double
+}

--- a/src/commonMain/kotlin/org/kbson/BsonObjectId.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonObjectId.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import org.kbson.ext.AtomicInt
+import org.kbson.ext.getCurrentTimeInSeconds
+
+/**
+ *
+ * <p>A globally unique identifier for objects.</p>
+ *
+ * <p>Consists of 12 bytes, divided as follows:</p> <table border="1"> <caption>ObjectID
+ * layout</caption> <tr>
+ * <td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td><td>9</td><td>10</td><td>11</td>
+ * </tr> <tr><td colspan="4">time</td><td colspan="5">random value</td><td colspan="3">inc</td></tr>
+ * </table>
+ *
+ * <p>Instances of this class are immutable.</p>
+ */
+class BsonObjectId(
+    val timestamp: Int,
+    val randomValue1: Int,
+    val randomValue2: Short,
+    val counter: Int
+) : BsonValue(), Comparable<BsonObjectId> {
+
+    init {
+        require((randomValue1 and -0x1000000) == 0) {
+            "The random value must be between 0 and 16777215 (it must fit in three bytes)."
+        }
+        require((counter and -0x1000000) == 0) {
+            "The counter must be between 0 and 16777215 (it must fit in three bytes)."
+        }
+    }
+
+    /**
+     * Convert to a byte array. Note that the numbers are stored in big-endian order.
+     *
+     * @return the byte array
+     */
+    fun toByteArray(): ByteArray {
+        val bytes = ByteArray(OBJECT_ID_LENGTH)
+        bytes[0] = (timestamp shr 24).toByte()
+        bytes[1] = (timestamp shr 16).toByte()
+        bytes[2] = (timestamp shr 8).toByte()
+        bytes[3] = timestamp.toByte()
+        bytes[4] = (randomValue1 shr 16).toByte()
+        bytes[5] = (randomValue1 shr 8).toByte()
+        bytes[6] = randomValue1.toByte()
+        bytes[7] = (randomValue2.toInt() shr 8).toByte()
+        bytes[8] = randomValue2.toByte()
+        bytes[9] = (counter shr 16).toByte()
+        bytes[10] = (counter shr 8).toByte()
+        bytes[11] = counter.toByte()
+        return bytes
+    }
+
+    /**
+     * Converts this instance into a 24-byte hexadecimal string representation.
+     *
+     * @return a string representation of the ObjectId in hexadecimal format
+     */
+    fun toHexString(): String {
+        val chars = CharArray(OBJECT_ID_LENGTH * 2)
+        var i = 0
+        for (b in toByteArray()) {
+            chars[i++] = HEX_CHARS[b.toInt() shr 4 and 0xF]
+            chars[i++] = HEX_CHARS[b.toInt() and 0xF]
+        }
+        return chars.concatToString()
+    }
+
+    override fun getBsonType(): BsonType = BsonType.OBJECT_ID
+
+    override fun toString(): String {
+        return "BsonObjectId(${toHexString()})"
+    }
+
+    override fun compareTo(other: BsonObjectId): Int {
+        val byteArray = toByteArray()
+        val otherByteArray = other.toByteArray()
+        for (i in 0 until OBJECT_ID_LENGTH) {
+            if (byteArray[i] != otherByteArray[i]) {
+                return if (byteArray[i].toInt() and 0xff < otherByteArray[i].toInt() and 0xff) -1
+                else 1
+            }
+        }
+        return 0
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonObjectId
+
+        if (timestamp != other.timestamp) return false
+        if (randomValue1 != other.randomValue1) return false
+        if (randomValue2 != other.randomValue2) return false
+        if (counter != other.counter) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = timestamp
+        result = 31 * result + randomValue1
+        result = 31 * result + randomValue2
+        result = 31 * result + counter
+        return result
+    }
+
+    companion object {
+        private const val OBJECT_ID_LENGTH = 12
+        private const val LOW_ORDER_THREE_BYTES = 0x00ffffff
+        private val HEX_CHARS = "0123456789abcdef".toCharArray()
+
+        // Use primitives to represent the 5-byte random value.
+        private val RANDOM_VALUE1: Int
+        private val RANDOM_VALUE2: Short
+        private val NEXT_COUNTER: AtomicInt
+
+        init {
+            val random = kotlin.random.Random(getCurrentTimeInSeconds())
+            NEXT_COUNTER = AtomicInt(random.nextInt())
+            RANDOM_VALUE1 = random.nextInt(0x01000000)
+            RANDOM_VALUE2 = random.nextInt(0x00008000).toShort()
+        }
+
+        /** Create a new BsonObjectId */
+        operator fun invoke(): BsonObjectId {
+            return BsonObjectId(
+                getCurrentTimeInSeconds(), RANDOM_VALUE1, RANDOM_VALUE2, nextCounter())
+        }
+
+        /**
+         * Create a new BsonObjectId from a hexString
+         *
+         * @see [BsonObjectId.toHexString]
+         */
+        operator fun invoke(hexString: String): BsonObjectId {
+            val invalidHexString =
+                hexString.length != 24 ||
+                    hexString.none { c ->
+                        (c < '0' || c > '9') || (c < 'a' || c > 'f') || (c < 'A' || c > 'F')
+                    }
+            require(!invalidHexString) {
+                "invalid hexadecimal representation of an ObjectId: [$hexString]"
+            }
+            return invoke(hexString.chunked(2).map { it.toInt(16).toByte() }.toByteArray())
+        }
+
+        /** Construct a new BsonObjectId from a ByteArray */
+        operator fun invoke(byteArray: ByteArray): BsonObjectId {
+            require(byteArray.size == OBJECT_ID_LENGTH) {
+                "invalid byteArray.size() ${byteArray.size} != $OBJECT_ID_LENGTH"
+            }
+
+            var pos = 0
+            val timestamp =
+                makeInt(byteArray[pos++], byteArray[pos++], byteArray[pos++], byteArray[pos++])
+            val randomValue1 =
+                makeInt(0.toByte(), byteArray[pos++], byteArray[pos++], byteArray[pos++])
+            val randomValue2 = makeShort(byteArray[pos++], byteArray[pos++])
+            val counter = makeInt(0.toByte(), byteArray[pos++], byteArray[pos++], byteArray[pos])
+            return BsonObjectId(timestamp, randomValue1, randomValue2, counter)
+        }
+
+        private fun nextCounter(): Int = NEXT_COUNTER.addAndGet(1) and LOW_ORDER_THREE_BYTES
+
+        // Big-Endian helper, in this class because all other BSON numbers are little-endian
+        private fun makeInt(vararg bytes: Byte): Int {
+            require(bytes.size == 4) { "The byte array must be 4 bytes long." }
+            return (bytes[0].toInt() shl 24) or
+                (bytes[1].toInt() and 0xff shl 16) or
+                (bytes[2].toInt() and 0xff shl 8) or
+                (bytes[3].toInt() and 0xff)
+        }
+
+        private fun makeShort(vararg bytes: Byte): Short {
+            require(bytes.size == 2) { "The byte array must be 2 bytes long." }
+            return (bytes[0].toInt() and 0xff shl 8 or (bytes[1].toInt() and 0xff)).toShort()
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonRegularExpression.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonRegularExpression.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the BSON regular expression type */
+class BsonRegularExpression(val pattern: String, options: String) : BsonValue() {
+
+    /**
+     * Gets the options for the regular expression
+     *
+     * @return the options.
+     */
+    val options: String
+
+    init {
+        this.options = options.toCharArray().apply { sort() }.joinToString("")
+    }
+
+    /** Construct a new instance without any options */
+    constructor(pattern: String) : this(pattern, "")
+
+    override fun getBsonType(): BsonType = BsonType.REGULAR_EXPRESSION
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonRegularExpression
+
+        if (pattern != other.pattern) return false
+        if (options != other.options) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = pattern.hashCode()
+        result = 31 * result + options.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "BsonRegularExpression(pattern='$pattern', options='$options')"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonString.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonString.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation of the BSON String type. */
+class BsonString(val value: String) : BsonValue(), Comparable<BsonString> {
+    override fun getBsonType(): BsonType = BsonType.STRING
+
+    override fun compareTo(other: BsonString): Int {
+        return value.compareTo(other.value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonString
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonString(value='$value')"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonSymbol.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonSymbol.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/**
+ * A representation of the BSON Symbol type.
+ *
+ * <p>Note: It's deprecated in BSON Specification and present here only for compatibility reasons.
+ */
+class BsonSymbol(val symbol: String) : BsonValue() {
+    override fun getBsonType(): BsonType = BsonType.SYMBOL
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonSymbol
+
+        if (symbol != other.symbol) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return symbol.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonSymbol(value='$symbol')"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonTimestamp.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonTimestamp.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** A representation the BSON timestamp type. */
+class BsonTimestamp(val value: Long = 0) : BsonValue(), Comparable<BsonTimestamp> {
+
+    /**
+     * Construct a new instance for the given time and increment.
+     *
+     * @param seconds the number of seconds since the epoch
+     * @param increment the increment.
+     */
+    constructor(
+        seconds: Int,
+        increment: Int
+    ) : this((seconds.toLong() shl 32) or (increment.toLong() and 0xFFFFFFFFL))
+
+    override fun getBsonType(): BsonType = BsonType.TIMESTAMP
+
+    /**
+     * Gets the time in seconds since epoch.
+     *
+     * @return an int representing time in seconds since epoch
+     */
+    fun getTime(): Int = (value shr 32).toInt()
+
+    /**
+     * Gets the increment value.
+     *
+     * @return an incrementing ordinal for operations within a given second
+     */
+    fun getInc(): Int = value.toInt()
+
+    override fun compareTo(other: BsonTimestamp): Int {
+        return value.compareTo(other.value)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BsonTimestamp
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonTimestamp(value=$value)"
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonType.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonType.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** Enumeration of all the BSON types currently supported. */
+enum class BsonType(
+    /**
+     * Get the int value of this BSON type.
+     *
+     * @return the int value of this type.
+     */
+    val value: Int
+) {
+    /** Not a real BSON type. Used to signal the end of a document. */
+    END_OF_DOCUMENT(0x00), // no values of this type exist it marks the end of a document
+
+    /** A BSON double. */
+    DOUBLE(0x01),
+
+    /** A BSON string. */
+    STRING(0x02),
+
+    /** A BSON document. */
+    DOCUMENT(0x03),
+
+    /** A BSON array. */
+    ARRAY(0x04),
+
+    /** BSON binary data. */
+    BINARY(0x05),
+
+    /** A BSON undefined value. */
+    UNDEFINED(0x06),
+
+    /** A BSON ObjectId. */
+    OBJECT_ID(0x07),
+
+    /** A BSON bool. */
+    BOOLEAN(0x08),
+
+    /** A BSON DateTime. */
+    DATE_TIME(0x09),
+
+    /** A BSON null value. */
+    NULL(0x0a),
+
+    /** A BSON regular expression. */
+    REGULAR_EXPRESSION(0x0b),
+
+    /** A BSON regular expression. */
+    DB_POINTER(0x0c),
+
+    /** BSON JavaScript code. */
+    JAVASCRIPT(0x0d),
+
+    /** A BSON symbol. */
+    SYMBOL(0x0e),
+
+    /** BSON JavaScript code with a scope (a set of variables with values). */
+    JAVASCRIPT_WITH_SCOPE(0x0f),
+
+    /** A BSON 32-bit integer. */
+    INT32(0x10),
+
+    /** A BSON timestamp. */
+    TIMESTAMP(0x11),
+
+    /** A BSON 64-bit integer. */
+    INT64(0x12),
+
+    /**
+     * A BSON Decimal128.
+     *
+     * @since 3.4
+     */
+    DECIMAL128(0x13),
+
+    /** A BSON MinKey value. */
+    MIN_KEY(0xff),
+
+    /** A BSON MaxKey value. */
+    MAX_KEY(0x7f);
+
+    /**
+     * Returns whether this type is some sort of containing type, e.g. a document or array.
+     *
+     * @return true if this is some sort of containing type rather than a primitive value
+     */
+    open fun isContainer(): Boolean {
+        return this == DOCUMENT || this == ARRAY
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonUndefined.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonUndefined.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/**
+ * A representation of the BSON Undefined type.
+ *
+ * <p>Note: It's deprecated in BSON Specification and present here only for compatibility reasons.
+ */
+class BsonUndefined : BsonValue() {
+
+    override fun getBsonType(): BsonType {
+        return BsonType.UNDEFINED
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return this::class.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BsonUndefined()"
+    }
+
+    companion object {
+        val UNDEFINED: BsonUndefined = BsonUndefined()
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/BsonValue.kt
+++ b/src/commonMain/kotlin/org/kbson/BsonValue.kt
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+/** Base class for any BSON type. */
+sealed class BsonValue protected constructor() {
+
+    /**
+     * Gets the BSON type of this value.
+     *
+     * @return the BSON type, which may not be null (but may be BSONType.NULL)
+     */
+    abstract fun getBsonType(): BsonType
+
+    /** @return true if this is a BsonNull, false otherwise */
+    open fun isNull(): Boolean {
+        return this is BsonNull
+    }
+
+    /** @return true if this is a BsonDocument, false otherwise */
+    open fun isDocument(): Boolean {
+        return this is BsonDocument
+    }
+
+    /** @return true if this is a BsonArray, false otherwise */
+    open fun isArray(): Boolean {
+        return this is BsonArray
+    }
+
+    /** @return true if this is a BsonString, false otherwise */
+    open fun isString(): Boolean {
+        return this is BsonString
+    }
+
+    /** @return true if this is a BsonNumber, false otherwise */
+    open fun isNumber(): Boolean {
+        return isInt32() || isInt64() || isDouble()
+    }
+
+    /** @return true if this is a BsonInt32, false otherwise */
+    open fun isInt32(): Boolean {
+        return this is BsonInt32
+    }
+
+    /** @return true if this is a BsonInt64, false otherwise */
+    open fun isInt64(): Boolean {
+        return this is BsonInt64
+    }
+
+    /** @return true if this is a BsonDecimal128, false otherwise */
+    open fun isDecimal128(): Boolean {
+        return this is BsonDecimal128
+    }
+
+    /** @return true if this is a BsonDouble, false otherwise */
+    open fun isDouble(): Boolean {
+        return this is BsonDouble
+    }
+
+    /** @return true if this is a BsonBoolean, false otherwise */
+    open fun isBoolean(): Boolean {
+        return this is BsonBoolean
+    }
+
+    /** @return true if this is an BsonObjectId, false otherwise */
+    open fun isObjectId(): Boolean {
+        return this is BsonObjectId
+    }
+
+    /** @return true if this is a BsonDbPointer, false otherwise */
+    open fun isDBPointer(): Boolean {
+        return this is BsonDbPointer
+    }
+
+    /** @return true if this is a BsonTimestamp, false otherwise */
+    open fun isTimestamp(): Boolean {
+        return this is BsonTimestamp
+    }
+
+    /** @return true if this is a BsonBinary, false otherwise */
+    open fun isBinary(): Boolean {
+        return this is BsonBinary
+    }
+
+    /** @return true if this is a BsonDateTime, false otherwise */
+    open fun isDateTime(): Boolean {
+        return this is BsonDateTime
+    }
+
+    /** @return true if this is a BsonSymbol, false otherwise */
+    open fun isSymbol(): Boolean {
+        return this is BsonSymbol
+    }
+
+    /** @return true if this is a BsonRegularExpression, false otherwise */
+    open fun isRegularExpression(): Boolean {
+        return this is BsonRegularExpression
+    }
+
+    /** @return true if this is a BsonJavaScript, false otherwise */
+    open fun isJavaScript(): Boolean {
+        return this is BsonJavaScript
+    }
+
+    /** @return true if this is a BsonJavaScriptWithScope, false otherwise */
+    open fun isJavaScriptWithScope(): Boolean {
+        return this is BsonJavaScriptWithScope
+    }
+
+    /** @return true if this is a BsonMaxKey, false otherwise */
+    open fun isMaxKey(): Boolean {
+        return this is BsonMaxKey
+    }
+
+    /** @return true if this is a BsonMinKey, false otherwise */
+    open fun isMinKey(): Boolean {
+        return this is BsonMinKey
+    }
+
+    /** @return true if this is a BsonUndefined, false otherwise */
+    open fun isUndefined(): Boolean {
+        return this is BsonUndefined
+    }
+
+    /**
+     * Gets this value as a BsonDocument if it is one, otherwise throws exception
+     *
+     * @return a BsonDocument
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asDocument(): BsonDocument {
+        throwIfInvalidType(BsonType.DOCUMENT)
+        return this as BsonDocument
+    }
+
+    /**
+     * Gets this value as a BsonArray if it is one, otherwise throws exception
+     *
+     * @return a BsonArray
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asArray(): BsonArray {
+        throwIfInvalidType(BsonType.ARRAY)
+        return this as BsonArray
+    }
+
+    /**
+     * Gets this value as a BsonString if it is one, otherwise throws exception
+     *
+     * @return a BsonString
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asString(): BsonString {
+        throwIfInvalidType(BsonType.STRING)
+        return this as BsonString
+    }
+
+    /**
+     * Gets this value as a BsonNumber if it is one, otherwise throws exception
+     *
+     * @return a BsonNumber
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asNumber(): BsonNumber {
+        if (getBsonType() !== BsonType.INT32 &&
+            getBsonType() !== BsonType.INT64 &&
+            getBsonType() !== BsonType.DOUBLE) {
+            throw BsonInvalidOperationException(
+                "Value expected to be of a numerical BSON type is of unexpected type ${getBsonType()}")
+        }
+        return this as BsonNumber
+    }
+
+    /**
+     * Gets this value as a BsonInt32 if it is one, otherwise throws exception
+     *
+     * @return a BsonInt32
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asInt32(): BsonInt32 {
+        throwIfInvalidType(BsonType.INT32)
+        return this as BsonInt32
+    }
+
+    /**
+     * Gets this value as a BsonInt64 if it is one, otherwise throws exception
+     *
+     * @return a BsonInt64
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asInt64(): BsonInt64 {
+        throwIfInvalidType(BsonType.INT64)
+        return this as BsonInt64
+    }
+
+    /**
+     * Gets this value as a BsonDecimal128 if it is one, otherwise throws exception
+     *
+     * @return a BsonDecimal128
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     * @since 3.4
+     */
+    open fun asDecimal128(): BsonDecimal128 {
+        throwIfInvalidType(BsonType.DECIMAL128)
+        return this as BsonDecimal128
+    }
+
+    /**
+     * Gets this value as a BsonDouble if it is one, otherwise throws exception
+     *
+     * @return a BsonDouble
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asDouble(): BsonDouble {
+        throwIfInvalidType(BsonType.DOUBLE)
+        return this as BsonDouble
+    }
+
+    /**
+     * Gets this value as a BsonBoolean if it is one, otherwise throws exception
+     *
+     * @return a BsonBoolean
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asBoolean(): BsonBoolean {
+        throwIfInvalidType(BsonType.BOOLEAN)
+        return this as BsonBoolean
+    }
+
+    /**
+     * Gets this value as an BsonObjectId if it is one, otherwise throws exception
+     *
+     * @return an BsonObjectId
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asObjectId(): BsonObjectId {
+        throwIfInvalidType(BsonType.OBJECT_ID)
+        return this as BsonObjectId
+    }
+
+    /**
+     * Gets this value as a BsonDbPointer if it is one, otherwise throws exception
+     *
+     * @return an BsonDbPointer
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asDBPointer(): BsonDbPointer {
+        throwIfInvalidType(BsonType.DB_POINTER)
+        return this as BsonDbPointer
+    }
+
+    /**
+     * Gets this value as a BsonTimestamp if it is one, otherwise throws exception
+     *
+     * @return an BsonTimestamp
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asTimestamp(): BsonTimestamp {
+        throwIfInvalidType(BsonType.TIMESTAMP)
+        return this as BsonTimestamp
+    }
+
+    /**
+     * Gets this value as a BsonBinary if it is one, otherwise throws exception
+     *
+     * @return an BsonBinary
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asBinary(): BsonBinary {
+        throwIfInvalidType(BsonType.BINARY)
+        return this as BsonBinary
+    }
+
+    /**
+     * Gets this value as a BsonDateTime if it is one, otherwise throws exception
+     *
+     * @return an BsonDateTime
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asDateTime(): BsonDateTime {
+        throwIfInvalidType(BsonType.DATE_TIME)
+        return this as BsonDateTime
+    }
+
+    /**
+     * Gets this value as a BsonSymbol if it is one, otherwise throws exception
+     *
+     * @return an BsonSymbol
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asSymbol(): BsonSymbol {
+        throwIfInvalidType(BsonType.SYMBOL)
+        return this as BsonSymbol
+    }
+
+    /**
+     * Gets this value as a BsonRegularExpression if it is one, otherwise throws exception
+     *
+     * @return an BsonRegularExpression
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asRegularExpression(): BsonRegularExpression {
+        throwIfInvalidType(BsonType.REGULAR_EXPRESSION)
+        return this as BsonRegularExpression
+    }
+
+    /**
+     * Gets this value as a `BsonJavaScript` if it is one, otherwise throws exception
+     *
+     * @return a BsonJavaScript
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asJavaScript(): BsonJavaScript {
+        throwIfInvalidType(BsonType.JAVASCRIPT)
+        return this as BsonJavaScript
+    }
+
+    /**
+     * Gets this value as a BsonJavaScriptWithScope if it is one, otherwise throws exception
+     *
+     * @return a BsonJavaScriptWithScope
+     * @throws org.kbson.BsonInvalidOperationException if this value is not of the expected type
+     */
+    open fun asJavaScriptWithScope(): BsonJavaScriptWithScope {
+        throwIfInvalidType(BsonType.JAVASCRIPT_WITH_SCOPE)
+        return this as BsonJavaScriptWithScope
+    }
+
+    private fun throwIfInvalidType(expectedType: BsonType) {
+        if (getBsonType() !== expectedType) {
+            throw BsonInvalidOperationException(
+                "Value expected to be of type $expectedType is of unexpected type ${getBsonType()}")
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/kbson/ext/AtomicInt.kt
+++ b/src/commonMain/kotlin/org/kbson/ext/AtomicInt.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+/** Cross-platform atomic integer */
+expect class AtomicInt(value: Int) {
+
+    /** Gets the current value */
+    fun getValue(): Int
+
+    /**
+     * Increments the value by [delta] and returns the new value.
+     *
+     * @param delta the value to add
+     * @return the new value
+     */
+    fun addAndGet(delta: Int): Int
+
+    /**
+     * Compares value with [expected] and replaces it with [new] value if values matches.
+     *
+     * @param expected the expected value
+     * @param new the new value
+     * @return true if successful
+     */
+    fun compareAndSet(expected: Int, new: Int): Boolean
+
+    /** Increments value by one. */
+    fun increment()
+
+    /** Decrements value by one. */
+    fun decrement()
+}

--- a/src/commonMain/kotlin/org/kbson/ext/CurrentTime.kt
+++ b/src/commonMain/kotlin/org/kbson/ext/CurrentTime.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+expect fun getCurrentTimeInMillis(): Long
+
+expect fun getCurrentTimeInSeconds(): Int

--- a/src/commonTest/kotlin/org/kbson/BsonArrayTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonArrayTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonArrayTest {
+
+    val listOfBsonValues = listOf(BsonBoolean.TRUE, BsonBoolean.FALSE)
+    val bsonValue = BsonArray(listOfBsonValues)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isArray() }
+        assertEquals(BsonType.ARRAY, BsonArray().getBsonType())
+    }
+
+    @Test
+    fun shouldConstructAnEmptyArray() {
+        val bsonValue = BsonArray()
+
+        assertTrue(bsonValue.isEmpty())
+        assertEquals(0, bsonValue.size)
+        assertTrue(bsonValue.values.isEmpty())
+    }
+
+    @Test
+    fun shouldConstructWithInitialCapacity() {
+        val bsonValue = BsonArray(10)
+
+        assertTrue(bsonValue.isEmpty())
+        assertEquals(0, bsonValue.size)
+        assertTrue(bsonValue.values.isEmpty())
+    }
+
+    @Test
+    fun shouldConstructFromAList() {
+        assertFalse(bsonValue.isEmpty())
+        assertEquals(2, bsonValue.size)
+        assertContentEquals(listOfBsonValues, bsonValue.values)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(BsonArray(), BsonArray())
+        assertEquals(bsonValue, bsonValue)
+        assertNotEquals(BsonArray(), bsonValue)
+        assertNotEquals(bsonValue, BsonArray(listOf(BsonBoolean.TRUE, BsonBoolean.TRUE)))
+    }
+
+    @Test
+    fun shouldSupportListMethods() {
+        assertTrue(bsonValue.contains(BsonBoolean.TRUE))
+        assertFalse(bsonValue.contains(BsonUndefined.UNDEFINED))
+
+        assertTrue(bsonValue.containsAll(listOf(BsonBoolean.TRUE)))
+        assertFalse(bsonValue.containsAll(listOf(BsonBoolean.TRUE, BsonUndefined.UNDEFINED)))
+
+        val iterator = bsonValue.iterator()
+        assertTrue(iterator.hasNext())
+        assertEquals(BsonBoolean.TRUE, iterator.next())
+        assertTrue(iterator.hasNext())
+        assertEquals(BsonBoolean.FALSE, iterator.next())
+        assertFalse(iterator.hasNext())
+
+        val listIterator = bsonValue.listIterator()
+        assertFalse(listIterator.hasPrevious())
+        assertTrue(listIterator.hasNext())
+        assertEquals(BsonBoolean.TRUE, listIterator.next())
+        assertEquals(BsonBoolean.TRUE, listIterator.previous())
+        assertEquals(BsonBoolean.TRUE, listIterator.next())
+        assertEquals(BsonBoolean.FALSE, listIterator.next())
+        assertTrue(listIterator.hasPrevious())
+        assertFalse(listIterator.hasNext())
+
+        val subListIterator = bsonValue.listIterator(1)
+        assertTrue(subListIterator.hasPrevious())
+        assertTrue(subListIterator.hasNext())
+        assertEquals(BsonBoolean.FALSE, subListIterator.next())
+        assertTrue(subListIterator.hasPrevious())
+        assertFalse(subListIterator.hasNext())
+
+        assertEquals(listOf(BsonBoolean.FALSE), bsonValue.subList(1, 2))
+        assertEquals(
+            2,
+            BsonArray(listOf(BsonBoolean.TRUE, BsonBoolean.TRUE, BsonBoolean.TRUE))
+                .lastIndexOf(BsonBoolean.TRUE))
+        assertEquals(1, bsonValue.indexOf(BsonBoolean.FALSE))
+    }
+
+    @Test
+    fun cloneShouldMakeADeepCopyOfAllMutableBsonValueTypes() {
+        val bsonArray =
+            BsonArray(
+                listOf(
+                    BsonInt32(3),
+                    BsonArray(listOf(BsonInt32(11))),
+                    BsonDocument("i3", BsonInt32(6)),
+                    BsonBinary(listOf(1.toByte(), 2.toByte(), 3.toByte()).toByteArray()),
+                    BsonJavaScriptWithScope("code", BsonDocument("a", BsonInt32(4)))))
+
+        val clonedArray = bsonArray.clone()
+
+        assertEquals(bsonArray, clonedArray)
+        assertNotSame(bsonArray, clonedArray)
+
+        // Immutable types are the same
+        assertSame(bsonArray[0], clonedArray[0])
+        assertSame(bsonArray[3], clonedArray[3])
+        assertSame(bsonArray[4], clonedArray[4])
+
+        // Mutable types are copies
+        assertNotSame(bsonArray[1], clonedArray[1])
+        assertNotSame(bsonArray[2], clonedArray[2])
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonBinaryTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonBinaryTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class BsonBinaryTest {
+
+    private val data =
+        listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+            .map { it.toByte() }
+            .toByteArray()
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { BsonBinary(data).isBinary() }
+        assertEquals(BsonType.BINARY, BsonBinary(data).getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        val bsonValue = BsonBinary(data)
+
+        assertEquals(data, bsonValue.data)
+        assertEquals(BsonBinarySubType.BINARY.value, bsonValue.type)
+    }
+
+    @Test
+    fun shouldInitializeWithDataAndSubType() {
+        var bsonValue = BsonBinary(BsonBinarySubType.BINARY, data)
+
+        assertEquals(BsonBinarySubType.BINARY.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.FUNCTION, data)
+        assertEquals(BsonBinarySubType.FUNCTION.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.MD5, data)
+        assertEquals(BsonBinarySubType.MD5.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.OLD_BINARY, data)
+        assertEquals(BsonBinarySubType.OLD_BINARY.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.USER_DEFINED, data)
+        assertEquals(BsonBinarySubType.USER_DEFINED.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.UUID_LEGACY, data)
+        assertEquals(BsonBinarySubType.UUID_LEGACY.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.UUID_STANDARD, data)
+        assertEquals(BsonBinarySubType.UUID_STANDARD.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.ENCRYPTED, data)
+        assertEquals(BsonBinarySubType.ENCRYPTED.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+
+        bsonValue = BsonBinary(BsonBinarySubType.COLUMN, data)
+        assertEquals(BsonBinarySubType.COLUMN.value, bsonValue.type)
+        assertEquals(data, bsonValue.data)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(
+            BsonBinary(BsonBinarySubType.BINARY, data), BsonBinary(BsonBinarySubType.BINARY, data))
+        assertNotEquals(
+            BsonBinary(BsonBinarySubType.BINARY, data),
+            BsonBinary(BsonBinarySubType.USER_DEFINED, data))
+    }
+
+    @Test
+    fun implementsClone() {
+        val original = BsonBinary(BsonBinarySubType.BINARY, data)
+        val clone = BsonBinary.clone(original)
+        assertEquals(original, clone)
+
+        original.data[0] = 9
+        assertNotEquals(original, clone)
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonBooleanTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonBooleanTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonBooleanTest {
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { BsonBoolean.TRUE.isBoolean() }
+        assertEquals(BsonType.BOOLEAN, BsonBoolean.TRUE.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertTrue(BsonBoolean.valueOf(true).value)
+        assertFalse(BsonBoolean.valueOf(false).value)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(BsonBoolean.TRUE, BsonBoolean(true))
+        assertEquals(BsonBoolean.FALSE, BsonBoolean(false))
+        assertNotEquals(BsonBoolean.TRUE, BsonBoolean(false))
+        assertNotEquals(BsonBoolean.FALSE, BsonBoolean(true))
+    }
+
+    @Test
+    fun shouldBeComparable() {
+        assertEquals(-1, BsonBoolean.FALSE.compareTo(BsonBoolean.TRUE))
+        assertEquals(0, BsonBoolean.TRUE.compareTo(BsonBoolean.TRUE))
+        assertEquals(0, BsonBoolean.FALSE.compareTo(BsonBoolean.FALSE))
+        assertEquals(1, BsonBoolean.TRUE.compareTo(BsonBoolean.FALSE))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonDateTimeTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonDateTimeTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.kbson.ext.getCurrentTimeInMillis
+
+class BsonDateTimeTest {
+
+    private val bsonDateTime = BsonDateTime()
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonDateTime.isDateTime() }
+        assertEquals(BsonType.DATE_TIME, bsonDateTime.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        val bsonValue = BsonDateTime(0)
+        assertEquals(0, bsonValue.value)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(BsonDateTime(0), BsonDateTime(0))
+        assertNotEquals(BsonDateTime(1), BsonDateTime(0))
+    }
+
+    @Test
+    fun shouldBeComparable() {
+        val zeroBsonValue = BsonDateTime(0)
+        val nowBsonValue = delayedBsonDateTime()
+        val latestBsonValue = BsonDateTime(Long.MAX_VALUE)
+
+        assertEquals(-1, zeroBsonValue.compareTo(nowBsonValue))
+        assertEquals(0, zeroBsonValue.compareTo(zeroBsonValue))
+        assertEquals(1, nowBsonValue.compareTo(zeroBsonValue))
+
+        assertEquals(-1, bsonDateTime.compareTo(nowBsonValue))
+        assertEquals(1, latestBsonValue.compareTo(nowBsonValue))
+    }
+
+    private fun delayedBsonDateTime(defaultTime: Long = bsonDateTime.value): BsonDateTime {
+        // There is no sleep method so this busy loop
+        // forces at least 1 ms difference between current times.
+        var currentTime = defaultTime
+        while (currentTime == defaultTime) {
+            currentTime = getCurrentTimeInMillis()
+        }
+        return BsonDateTime()
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonDbPointerTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonDbPointerTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonDbPointerTest {
+
+    private val namespace = "namespace"
+    private val id = BsonObjectId()
+    private val bsonValue = BsonDbPointer(namespace, id)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isDBPointer() }
+        assertEquals(BsonType.DB_POINTER, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(namespace, bsonValue.namespace)
+        assertEquals(id, bsonValue.id)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonDbPointer(namespace, id))
+        assertNotEquals(bsonValue, BsonDbPointer("altNamespace", id))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonDecimal128Test.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonDecimal128Test.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonDecimal128Test {
+
+    private val bsonValue = BsonDecimal128(1, 2)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isDecimal128() }
+        assertEquals(BsonType.DECIMAL128, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(1, bsonValue.high)
+        assertEquals(2, bsonValue.low)
+    }
+
+    @Test
+    fun shouldHaveDecimalSpecificMethods() {
+        assertFalse(BsonDecimal128(1, 1).isNegative())
+        assertTrue(BsonDecimal128(-1, 0x0000000000000000L).isNegative())
+        assertTrue(BsonDecimal128(-0x4fc0000000000000L, 0x0000000000000000L).isNegative())
+        assertTrue(BsonDecimal128(-0x800000000000000L, 0x0000000000000000L).isNegative())
+        assertTrue(BsonDecimal128(1, 0x0000000000000000L).isFinite())
+        assertTrue(BsonDecimal128(0x7800000000000000L, 0x0000000000000000L).isInfinite())
+        assertTrue(BsonDecimal128(-0x800000000000000L, 0x0000000000000000L).isInfinite())
+        assertTrue(BsonDecimal128(0x7c00000000000000L, 0x0000000000000000L).isNaN())
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonDecimal128(1L, 2L))
+        assertNotEquals(bsonValue, BsonDecimal128(2, 2))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonDocumentTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonDocumentTest.kt
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonDocumentTest {
+
+    private val bsonNull = BsonNull()
+    private val bsonInt32 = BsonInt32(42)
+    private val bsonInt64 = BsonInt64(52L)
+    private val bsonDecimal128 = BsonDecimal128(1, 0)
+    private val bsonBoolean = BsonBoolean(true)
+    private val bsonDateTime = BsonDateTime()
+    private val bsonDouble = BsonDouble(62.0)
+    private val bsonString = BsonString("the fox ...")
+    private val bsonMinKey = BsonMinKey()
+    private val bsonMaxKey = BsonMaxKey()
+    private val bsonJavaScript = BsonJavaScript("int i = 0;")
+    private val bsonObjectId = BsonObjectId()
+    private val bsonJavaScriptWithScope =
+        BsonJavaScriptWithScope("int x = y", BsonDocument("y", BsonInt32(1)))
+    private val bsonRegularExpression = BsonRegularExpression("^test.*regex.*xyz$", "i")
+    private val bsonSymbol = BsonSymbol("ruby stuff")
+    private val bsonTimestamp = BsonTimestamp(0x12345678, 5)
+    private val bsonUndefined = BsonUndefined()
+    private val bsonBinary =
+        BsonBinary(
+            80.toByte(),
+            listOf(5.toByte(), 4.toByte(), 3.toByte(), 2.toByte(), 1.toByte()).toByteArray())
+    private val bsonArray =
+        BsonArray(
+            listOf(
+                BsonInt32(1),
+                BsonInt64(2L),
+                BsonBoolean(true),
+                BsonArray(listOf(BsonInt32(1), BsonInt32(2), BsonInt32(3))),
+                BsonDocument("a", BsonInt64(2L))))
+    private val bsonDocument = BsonDocument("a", BsonInt32(1))
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonDocument.isDocument() }
+        assertEquals(BsonType.DOCUMENT, bsonDocument.getBsonType())
+    }
+
+    @Test
+    fun conversionMethodsShouldBehaveCorrectlyForTheHappyPath() {
+
+        val document =
+            BsonDocument(
+                Pair("null", bsonNull),
+                Pair("int32", bsonInt32),
+                Pair("int64", bsonInt64),
+                Pair("decimal128", bsonDecimal128),
+                Pair("boolean", bsonBoolean),
+                Pair("date", bsonDateTime),
+                Pair("double", bsonDouble),
+                Pair("string", bsonString),
+                Pair("minKey", bsonMinKey),
+                Pair("maxKey", bsonMaxKey),
+                Pair("javaScript", bsonJavaScript),
+                Pair("objectId", bsonObjectId),
+                Pair("codeWithScope", bsonJavaScriptWithScope),
+                Pair("regex", bsonRegularExpression),
+                Pair("symbol", bsonSymbol),
+                Pair("timestamp", bsonTimestamp),
+                Pair("undefined", bsonUndefined),
+                Pair("bsonBinary", bsonBinary),
+                Pair("array", bsonArray),
+                Pair("document", bsonDocument))
+
+        document.isNull("null")
+        assertEquals(bsonInt32, document.getInt32("int32"))
+        assertEquals(bsonInt64, document.getInt64("int64"))
+        assertEquals(bsonDecimal128, document.getDecimal128("decimal128"))
+        assertEquals(bsonBoolean, document.getBoolean("boolean"))
+        assertEquals(bsonDateTime, document.getDateTime("date"))
+        assertEquals(bsonDouble, document.getDouble("double"))
+        assertEquals(bsonString, document.getString("string"))
+        assertEquals(bsonObjectId, document.getObjectId("objectId"))
+        assertEquals(bsonRegularExpression, document.getRegularExpression("regex"))
+        assertEquals(bsonBinary, document.getBinary("bsonBinary"))
+        assertEquals(bsonTimestamp, document.getTimestamp("timestamp"))
+        assertEquals(bsonArray, document.getArray("array"))
+        assertEquals(bsonDocument, document.getDocument("document"))
+        assertEquals(bsonInt32, document.getNumber("int32"))
+        assertEquals(bsonInt64, document.getNumber("int64"))
+        assertEquals(bsonDouble, document.getNumber("double"))
+
+        assertEquals(bsonInt32, document.getInt32("int32", BsonInt32(2)))
+        assertEquals(bsonInt64, document.getInt64("int64", BsonInt64(4)))
+        assertEquals(bsonDecimal128, document.getDecimal128("decimal128", BsonDecimal128(1, 2)))
+        assertEquals(bsonDouble, document.getDouble("double", BsonDouble(343.0)))
+        assertEquals(bsonBoolean, document.getBoolean("boolean", BsonBoolean(false)))
+        assertEquals(bsonDateTime, document.getDateTime("date", BsonDateTime(3453)))
+        assertEquals(bsonString, document.getString("string", BsonString("df")))
+        assertEquals(bsonObjectId, document.getObjectId("objectId", BsonObjectId()))
+        assertEquals(
+            bsonRegularExpression,
+            document.getRegularExpression("regex", BsonRegularExpression("^foo", "i")))
+        assertEquals(
+            bsonBinary,
+            document.getBinary("bsonBinary", BsonBinary(listOf(5.toByte()).toByteArray())))
+        assertEquals(bsonTimestamp, document.getTimestamp("timestamp", BsonTimestamp(343, 23)))
+        assertEquals(bsonArray, document.getArray("array", BsonArray()))
+        assertEquals(bsonDocument, document.getDocument("document", BsonDocument()))
+        assertEquals(bsonInt32, document.getNumber("int32", BsonInt32(2)))
+        assertEquals(bsonInt64, document.getNumber("int64", BsonInt32(2)))
+        assertEquals(bsonDouble, document.getNumber("double", BsonInt32(2)))
+
+        assertEquals(bsonInt32, document.get("int32")!!.asInt32())
+        assertEquals(bsonInt64, document.get("int64")!!.asInt64())
+        assertEquals(bsonDecimal128, document.get("decimal128")!!.asDecimal128())
+        assertEquals(bsonBoolean, document.get("boolean")!!.asBoolean())
+        assertEquals(bsonDateTime, document.get("date")!!.asDateTime())
+        assertEquals(bsonDouble, document.get("double")!!.asDouble())
+        assertEquals(bsonString, document.get("string")!!.asString())
+        assertEquals(bsonObjectId, document.get("objectId")!!.asObjectId())
+        assertEquals(bsonTimestamp, document.get("timestamp")!!.asTimestamp())
+        assertEquals(bsonBinary, document.get("bsonBinary")!!.asBinary())
+        assertEquals(bsonArray, document.get("array")!!.asArray())
+        assertEquals(bsonDocument, document.get("document")!!.asDocument())
+
+        assertTrue(document.isInt32("int32"))
+        assertTrue(document.isNumber("int32"))
+        assertTrue(document.isInt64("int64"))
+        assertTrue(document.isDecimal128("decimal128"))
+        assertTrue(document.isNumber("int64"))
+        assertTrue(document.isBoolean("boolean"))
+        assertTrue(document.isDateTime("date"))
+        assertTrue(document.isDouble("double"))
+        assertTrue(document.isNumber("double"))
+        assertTrue(document.isString("string"))
+        assertTrue(document.isObjectId("objectId"))
+        assertTrue(document.isTimestamp("timestamp"))
+        assertTrue(document.isBinary("bsonBinary"))
+        assertTrue(document.isArray("array"))
+        assertTrue(document.isDocument("document"))
+    }
+
+    @Test
+    fun isTypeMethodsShouldReturnFalseForMissingKeys() {
+        val document = BsonDocument()
+
+        assertFalse(document.isNull("null"))
+        assertFalse(document.isNumber("number"))
+        assertFalse(document.isInt32("int32"))
+        assertFalse(document.isInt64("int64"))
+        assertFalse(document.isDecimal128("decimal128"))
+        assertFalse(document.isBoolean("boolean"))
+        assertFalse(document.isDateTime("date"))
+        assertFalse(document.isDouble("double"))
+        assertFalse(document.isString("string"))
+        assertFalse(document.isObjectId("objectId"))
+        assertFalse(document.isTimestamp("timestamp"))
+        assertFalse(document.isBinary("bsonBinary"))
+        assertFalse(document.isArray("array"))
+        assertFalse(document.isDocument("document"))
+    }
+
+    @Test
+    fun getMethodsShouldReturnDefaultValuesForMissingKeys() {
+        val document = BsonDocument()
+
+        assertEquals(bsonNull, document.get("m", bsonNull))
+        assertEquals(bsonArray, document.getArray("m", bsonArray))
+        assertEquals(bsonBoolean, document.getBoolean("m", bsonBoolean))
+        assertEquals(bsonDateTime, document.getDateTime("m", bsonDateTime))
+        assertEquals(bsonDocument, document.getDocument("m", bsonDocument))
+        assertEquals(bsonDouble, document.getDouble("m", bsonDouble))
+        assertEquals(bsonInt32, document.getInt32("m", bsonInt32))
+        assertEquals(bsonInt64, document.getInt64("m", bsonInt64))
+        assertEquals(bsonDecimal128, document.getDecimal128("m", bsonDecimal128))
+        assertEquals(bsonString, document.getString("m", bsonString))
+        assertEquals(bsonObjectId, document.getObjectId("m", bsonObjectId))
+        assertEquals(bsonString, document.getString("m", bsonString))
+        assertEquals(bsonTimestamp, document.getTimestamp("m", bsonTimestamp))
+        assertEquals(bsonInt32, document.getNumber("m", bsonInt32))
+        assertEquals(
+            bsonRegularExpression, document.getRegularExpression("m", bsonRegularExpression))
+        assertEquals(bsonBinary, document.getBinary("m", bsonBinary))
+    }
+
+    @Test
+    fun cloneShouldMakeADeepCopyOfAllMutableBsonValueTypes() {
+        val document =
+            BsonDocument("d", BsonDocument().append("i2", BsonInt32(1)))
+                .append("i", BsonInt32(2))
+                .append(
+                    "a",
+                    BsonArray(
+                        listOf(
+                            BsonInt32(3),
+                            BsonArray(listOf(BsonInt32(11))),
+                            BsonDocument("i3", BsonInt32(6)),
+                            BsonBinary(listOf(1.toByte(), 2.toByte(), 3.toByte()).toByteArray()),
+                            BsonJavaScriptWithScope("code", BsonDocument("a", BsonInt32(4))))))
+                .append("b", BsonBinary(listOf(1.toByte(), 2.toByte(), 3.toByte()).toByteArray()))
+                .append("js", BsonJavaScriptWithScope("code", BsonDocument("a", BsonInt32(4))))
+
+        val clone = document.clone()
+
+        assertEquals(document, clone)
+        assertNotSame(document, clone)
+
+        // Immutable types are the same
+        assertSame(document.get("i"), clone.get("i"))
+        assertSame(document.get("b"), clone.get("b"))
+        assertSame(document.get("js"), clone.get("js"))
+
+        // Mutable types are copies
+        assertNotSame(document.get("d"), clone.get("d"))
+        assertNotSame(document.get("a"), clone.get("a"))
+
+        // Test deep clone
+        val subArray = document.get("a")!!.asArray()
+        val clonedArray = clone.get("a")!!.asArray()
+
+        // Immutable types are the same
+        assertSame(subArray[0], clonedArray[0])
+        assertSame(subArray[3], clonedArray[3])
+        assertSame(subArray[4], clonedArray[4])
+
+        // Mutable types are copies
+        assertNotSame(subArray[1], clonedArray[1])
+        assertNotSame(subArray[2], clonedArray[2])
+    }
+
+    @Test
+    fun getMethodsShouldThrowIfKeyIsAbsent() {
+        val document = BsonDocument()
+
+        assertFailsWith<BsonInvalidOperationException> { document.getInt32("int32") }
+        assertFailsWith<BsonInvalidOperationException> { document.getInt64("int64") }
+        assertFailsWith<BsonInvalidOperationException> { document.getDecimal128("decimal128") }
+        assertFailsWith<BsonInvalidOperationException> { document.getBoolean("boolean") }
+        assertFailsWith<BsonInvalidOperationException> { document.getDateTime("date") }
+        assertFailsWith<BsonInvalidOperationException> { document.getDouble("double") }
+        assertFailsWith<BsonInvalidOperationException> { document.getString("string") }
+        assertFailsWith<BsonInvalidOperationException> { document.getObjectId("objectId") }
+        assertFailsWith<BsonInvalidOperationException> { document.getRegularExpression("regex") }
+        assertFailsWith<BsonInvalidOperationException> { document.getBinary("bsonBinary") }
+        assertFailsWith<BsonInvalidOperationException> { document.getTimestamp("timestamp") }
+        assertFailsWith<BsonInvalidOperationException> { document.getArray("array") }
+        assertFailsWith<BsonInvalidOperationException> { document.getDocument("document") }
+        assertFailsWith<BsonInvalidOperationException> { document.getNumber("int32") }
+    }
+
+    @Test
+    fun shouldGetFirstKey() {
+        val document = BsonDocument()
+
+        assertFailsWith<NoSuchElementException> { document.getFirstKey() }
+
+        document.put("i", bsonInt32)
+        assertEquals("i", document.getFirstKey())
+    }
+
+    @Test
+    fun shouldTestEquality() {
+        val emptyDocument = BsonDocument()
+        assertEquals(emptyDocument, BsonDocument())
+        assertEquals(emptyDocument, BsonDocument(0))
+        assertEquals(emptyDocument, BsonDocument(mapOf()))
+        assertEquals(emptyDocument, BsonDocument(listOf()))
+        assertEquals(
+            emptyDocument, BsonDocument(*arrayListOf<Pair<String, BsonValue>>().toTypedArray()))
+
+        val expectedDocument =
+            BsonDocument("null", bsonNull)
+                .append("int32", bsonInt32)
+                .append("int64", bsonInt64)
+                .append("decimal128", bsonDecimal128)
+                .append("boolean", bsonBoolean)
+                .append("date", bsonDateTime)
+                .append("double", bsonDouble)
+                .append("string", bsonString)
+                .append("minKey", bsonMinKey)
+                .append("maxKey", bsonMaxKey)
+                .append("javaScript", bsonJavaScript)
+                .append("objectId", bsonObjectId)
+                .append("codeWithScope", bsonJavaScriptWithScope)
+                .append("regex", bsonRegularExpression)
+                .append("symbol", bsonSymbol)
+                .append("timestamp", bsonTimestamp)
+                .append("undefined", bsonUndefined)
+                .append("bsonBinary", bsonBinary)
+                .append("array", bsonArray)
+                .append("document", bsonDocument)
+
+        val pairs =
+            arrayListOf(
+                Pair("null", bsonNull),
+                Pair("int32", bsonInt32),
+                Pair("int64", bsonInt64),
+                Pair("decimal128", bsonDecimal128),
+                Pair("boolean", bsonBoolean),
+                Pair("date", bsonDateTime),
+                Pair("double", bsonDouble),
+                Pair("string", bsonString),
+                Pair("minKey", bsonMinKey),
+                Pair("maxKey", bsonMaxKey),
+                Pair("javaScript", bsonJavaScript),
+                Pair("objectId", bsonObjectId),
+                Pair("codeWithScope", bsonJavaScriptWithScope),
+                Pair("regex", bsonRegularExpression),
+                Pair("symbol", bsonSymbol),
+                Pair("timestamp", bsonTimestamp),
+                Pair("undefined", bsonUndefined),
+                Pair("bsonBinary", bsonBinary),
+                Pair("array", bsonArray),
+                Pair("document", bsonDocument))
+
+        assertEquals(expectedDocument, BsonDocument(mapOf(*pairs.toTypedArray())))
+        assertEquals(expectedDocument, BsonDocument(pairs.map { BsonElement(it.first, it.second) }))
+        assertEquals(expectedDocument, BsonDocument(*pairs.toTypedArray()))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonDoubleTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonDoubleTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonDoubleTest {
+
+    private val bsonValue = BsonDouble(Double.MAX_VALUE)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isDouble() }
+        assertTrue { bsonValue.isNumber() }
+        assertEquals(BsonType.DOUBLE, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(Double.MAX_VALUE, bsonValue.value)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonDouble(Double.MAX_VALUE))
+        assertNotEquals(bsonValue, BsonDouble(Double.POSITIVE_INFINITY))
+    }
+
+    @Test
+    fun shouldBeComparable() {
+        assertEquals(-1, BsonDouble(Double.MIN_VALUE).compareTo(BsonDouble(Double.MAX_VALUE)))
+        assertEquals(0, BsonDouble(Double.MIN_VALUE).compareTo(BsonDouble(Double.MIN_VALUE)))
+        assertEquals(1, BsonDouble(Double.MAX_VALUE).compareTo(BsonDouble(Double.MIN_VALUE)))
+
+        assertEquals(
+            -1,
+            BsonDouble(Double.NEGATIVE_INFINITY).compareTo(BsonDouble(Double.POSITIVE_INFINITY)))
+        assertEquals(
+            1, BsonDouble(Double.POSITIVE_INFINITY).compareTo(BsonDouble(Double.NEGATIVE_INFINITY)))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonInt32Test.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonInt32Test.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonInt32Test {
+
+    private val bsonValue = BsonInt32(Int.MAX_VALUE)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isInt32() }
+        assertTrue { bsonValue.isNumber() }
+        assertEquals(BsonType.INT32, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(Int.MAX_VALUE, bsonValue.value)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonInt32(Int.MAX_VALUE))
+        assertNotEquals(bsonValue, BsonInt32(Int.MIN_VALUE))
+    }
+
+    @Test
+    fun shouldBeComparable() {
+        assertEquals(-1, BsonInt32(Int.MIN_VALUE).compareTo(BsonInt32(Int.MAX_VALUE)))
+        assertEquals(0, BsonInt32(Int.MIN_VALUE).compareTo(BsonInt32(Int.MIN_VALUE)))
+        assertEquals(1, BsonInt32(Int.MAX_VALUE).compareTo(BsonInt32(Int.MIN_VALUE)))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonInt64Test.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonInt64Test.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonInt64Test {
+
+    private val bsonValue = BsonInt64(Long.MAX_VALUE)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isInt64() }
+        assertTrue { bsonValue.isNumber() }
+        assertEquals(BsonType.INT64, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(Long.MAX_VALUE, bsonValue.value)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonInt64(Long.MAX_VALUE))
+        assertNotEquals(bsonValue, BsonInt64(Long.MIN_VALUE))
+    }
+
+    @Test
+    fun shouldBeComparable() {
+        assertEquals(-1, BsonInt64(Long.MIN_VALUE).compareTo(BsonInt64(Long.MAX_VALUE)))
+        assertEquals(0, BsonInt64(Long.MIN_VALUE).compareTo(BsonInt64(Long.MIN_VALUE)))
+        assertEquals(1, BsonInt64(Long.MAX_VALUE).compareTo(BsonInt64(Long.MIN_VALUE)))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonJavaScriptTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonJavaScriptTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonJavaScriptTest {
+
+    private val code = "function() {}"
+    private val bsonValue = BsonJavaScript(code)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isJavaScript() }
+        assertEquals(BsonType.JAVASCRIPT, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(code, bsonValue.code)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonJavaScript(code))
+        assertNotEquals(bsonValue, BsonJavaScript("function() { return false;}"))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonJavaScriptWithScopeTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonJavaScriptWithScopeTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonJavaScriptWithScopeTest {
+
+    private val code = "function() {}"
+    private val scope = BsonDocument()
+    private val bsonValue = BsonJavaScriptWithScope(code, scope)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isJavaScriptWithScope() }
+        assertEquals(BsonType.JAVASCRIPT_WITH_SCOPE, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(code, bsonValue.code)
+        assertEquals(scope, bsonValue.scope)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonJavaScriptWithScope(code, scope))
+        assertNotEquals(bsonValue, BsonJavaScriptWithScope("function() { return false;}", scope))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonMaxKeyTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonMaxKeyTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonMaxKeyTest {
+
+    private val bsonValue = BsonMaxKey()
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isMaxKey() }
+        assertEquals(BsonType.MAX_KEY, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonMaxKey())
+        assertNotEquals(bsonValue as BsonValue, BsonMinKey())
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonMinKeyTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonMinKeyTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonMinKeyTest {
+
+    private val bsonValue = BsonMinKey()
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isMinKey() }
+        assertEquals(BsonType.MIN_KEY, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonMinKey())
+        assertNotEquals(bsonValue as BsonValue, BsonMaxKey())
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonNullTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonNullTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonNullTest {
+
+    private val bsonValue = BsonNull.VALUE
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isNull() }
+        assertEquals(BsonType.NULL, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonNull())
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonNumberTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonNumberTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonNumberTest {
+
+    @Test
+    fun shouldConvertToInt() {
+        assertEquals(1, BsonInt32(1).intValue())
+
+        assertEquals(1, BsonInt64(1L).intValue())
+        assertEquals(-1, BsonInt64(Long.MAX_VALUE).intValue())
+        assertEquals(0, BsonInt64(Long.MIN_VALUE).intValue())
+
+        assertEquals(3, BsonDouble(3.14).intValue())
+    }
+
+    @Test
+    fun shouldConvertToLong() {
+        assertEquals(1L, BsonInt32(1).longValue())
+        assertEquals(1L, BsonInt64(1L).longValue())
+        assertEquals(3L, BsonDouble(3.14).longValue())
+    }
+
+    @Test
+    fun shouldConvertToDouble() {
+        assertEquals(1.0, BsonInt32(1).doubleValue())
+        assertEquals(1.0, BsonInt64(1L).doubleValue())
+
+        assertEquals(9.223372036854776E18, BsonInt64(Long.MAX_VALUE).doubleValue())
+        assertEquals(-9.223372036854776E18, BsonInt64(Long.MIN_VALUE).doubleValue())
+
+        assertEquals(3.14, BsonDouble(3.14).doubleValue())
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonObjectIdTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonObjectIdTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonObjectIdTest {
+
+    private val bsonValue = BsonObjectId("000000000000000000000000")
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isObjectId() }
+        assertEquals(BsonType.OBJECT_ID, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(0, bsonValue.timestamp)
+        assertEquals(0, bsonValue.randomValue1)
+        assertEquals(0, bsonValue.randomValue2)
+        assertEquals(0, bsonValue.counter)
+    }
+
+    @Test
+    fun testToBytes() {
+        val expectedBytes = byteArrayOf(81, 6, -4, -102, -68, -126, 55, 85, -127, 54, -46, -119)
+        assertContentEquals(expectedBytes, BsonObjectId(expectedBytes).toByteArray())
+    }
+
+    @Test
+    fun testFromBytes() {
+        assertFailsWith<IllegalArgumentException>("state should be: bytes has length of 12") {
+            BsonObjectId(ByteArray(11))
+        }
+        assertFailsWith<IllegalArgumentException>("state should be: bytes has length of 12") {
+            BsonObjectId(ByteArray(13))
+        }
+
+        val bytes = byteArrayOf(81, 6, -4, -102, -68, -126, 55, 85, -127, 54, -46, -119)
+        val objectId = BsonObjectId(bytes)
+        assertEquals(0x5106FC9A, objectId.timestamp)
+    }
+
+    @Test
+    fun testHexStringConstructor() {
+        val newId = BsonObjectId()
+        assertEquals(newId, BsonObjectId(newId.toHexString()))
+    }
+
+    @Test
+    fun testCompareTo() {
+        val first = BsonObjectId(0, 0, 0, 1)
+        val second = BsonObjectId(0, 1, 0, 1)
+        val third = BsonObjectId(1, 0, 0, 1)
+        assertEquals(0, first.compareTo(first))
+        assertEquals(-1, first.compareTo(second))
+        assertEquals(-1, first.compareTo(third))
+        assertEquals(1, second.compareTo(first))
+        assertEquals(1, third.compareTo(first))
+    }
+
+    @Test
+    fun testToHexString() {
+        assertEquals("000000000000000000000000", BsonObjectId(ByteArray(12)).toHexString())
+        assertEquals(
+            "7fffffff007fff7fff007fff",
+            BsonObjectId(byteArrayOf(127, -1, -1, -1, 0, 127, -1, 127, -1, 0, 127, -1))
+                .toHexString())
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonRegularExpressionTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonRegularExpressionTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonRegularExpressionTest {
+
+    private val pattern = "([a-z]+)"
+    private val options = "i"
+    private val bsonValue = BsonRegularExpression(pattern, options)
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isRegularExpression() }
+        assertEquals(BsonType.REGULAR_EXPRESSION, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals(pattern, bsonValue.pattern)
+        assertEquals(options, bsonValue.options)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonRegularExpression(pattern, options))
+        assertEquals(BsonRegularExpression(pattern), BsonRegularExpression(pattern, ""))
+        assertNotEquals(bsonValue, BsonRegularExpression("*.*", options))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonStringTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonStringTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonStringTest {
+
+    private val bsonValue = BsonString("string")
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isString() }
+        assertEquals(BsonType.STRING, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals("string", bsonValue.value)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonString("string"))
+        assertNotEquals(bsonValue, BsonString("STRING"))
+    }
+
+    @Test
+    fun shouldBeComparable() {
+        assertEquals(-1, BsonString("").compareTo(BsonString("a")))
+        assertEquals(0, BsonString("a").compareTo(BsonString("a")))
+        assertEquals(1, BsonString("aa").compareTo(BsonString("a")))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonSymbolTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonSymbolTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonSymbolTest {
+
+    private val bsonValue = BsonSymbol("s")
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isSymbol() }
+        assertEquals(BsonType.SYMBOL, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        assertEquals("s", bsonValue.symbol)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonSymbol("s"))
+        assertNotEquals(bsonValue, BsonSymbol("S"))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonTimestampTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonTimestampTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonTimestampTest {
+
+    private val bsonValue = BsonTimestamp()
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isTimestamp() }
+        assertEquals(BsonType.TIMESTAMP, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldHaveAccessToTheUnderlyingValues() {
+        val bsonValue = BsonTimestamp(120, 55)
+        assertEquals(120, bsonValue.getTime())
+        assertEquals(55, bsonValue.getInc())
+        assertEquals(515396075575, bsonValue.value)
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonTimestamp())
+        assertNotEquals(bsonValue, BsonTimestamp(1))
+    }
+
+    @Test
+    fun shouldBeComparable() {
+        assertEquals(-1, BsonTimestamp(Long.MIN_VALUE).compareTo(BsonTimestamp(Long.MAX_VALUE)))
+        assertEquals(0, BsonTimestamp(Long.MIN_VALUE).compareTo(BsonTimestamp(Long.MIN_VALUE)))
+        assertEquals(1, BsonTimestamp(Long.MAX_VALUE).compareTo(BsonTimestamp(Long.MIN_VALUE)))
+    }
+}

--- a/src/commonTest/kotlin/org/kbson/BsonUndefinedTest.kt
+++ b/src/commonTest/kotlin/org/kbson/BsonUndefinedTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import kotlin.test.*
+
+class BsonUndefinedTest {
+
+    private val bsonValue = BsonUndefined.UNDEFINED
+
+    @Test
+    fun shouldHaveTheExpectedBsonType() {
+        assertTrue { bsonValue.isUndefined() }
+        assertEquals(BsonType.UNDEFINED, bsonValue.getBsonType())
+    }
+
+    @Test
+    fun shouldOverrideEquals() {
+        assertEquals(bsonValue, BsonUndefined())
+    }
+}

--- a/src/jsMain/kotlin/org/kbson/ext/AtomicInt.kt
+++ b/src/jsMain/kotlin/org/kbson/ext/AtomicInt.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+/**
+ * Js version of an atomic integer
+ *
+ * In JavaScript, a function always runs to completion, before any other function is called. So
+ * there no locking required to protect the int.
+ */
+actual class AtomicInt actual constructor(value: Int) {
+
+    private var atomicInt: Int
+
+    init {
+        atomicInt = value
+    }
+
+    /** Gets the current value */
+    actual fun getValue(): Int = atomicInt
+    /**
+     * Increments the value by [delta] and returns the new value.
+     *
+     * @param delta the value to add
+     * @return the new value
+     */
+    actual fun addAndGet(delta: Int): Int {
+        atomicInt += delta
+        return atomicInt
+    }
+
+    /**
+     * Compares value with [expected] and replaces it with [new] value if values matches.
+     *
+     * @param expected the expected value
+     * @param new the new value
+     * @return true if successful
+     */
+    actual fun compareAndSet(expected: Int, new: Int): Boolean {
+        if (atomicInt == expected) {
+            atomicInt = new
+            return true
+        }
+        return false
+    }
+
+    /** Increments value by one. */
+    actual fun increment() {
+        atomicInt++
+    }
+
+    /** Decrements value by one. */
+    actual fun decrement() {
+        atomicInt--
+    }
+}

--- a/src/jsMain/kotlin/org/kbson/ext/getCurrentTime.kt
+++ b/src/jsMain/kotlin/org/kbson/ext/getCurrentTime.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+import kotlin.js.Date
+
+actual fun getCurrentTimeInMillis(): Long = Date.now().toLong()
+
+actual fun getCurrentTimeInSeconds(): Int = (getCurrentTimeInMillis() / 1000).toInt()

--- a/src/jvmMain/kotlin/org/kbson/ext/AtomicInt.kt
+++ b/src/jvmMain/kotlin/org/kbson/ext/AtomicInt.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/** A Jvm wrapper of atomic integer */
+actual class AtomicInt actual constructor(value: Int) {
+
+    val atomicInt: AtomicInteger
+
+    init {
+        atomicInt = AtomicInteger(value)
+    }
+
+    /** Gets the current value */
+    actual fun getValue(): Int = atomicInt.get()
+
+    /**
+     * Increments the value by [delta] and returns the new value.
+     *
+     * @param delta the value to add
+     * @return the new value
+     */
+    actual fun addAndGet(delta: Int): Int = atomicInt.addAndGet(delta)
+
+    /**
+     * Compares value with [expected] and replaces it with [new] value if values matches.
+     *
+     * @param expected the expected value
+     * @param new the new value
+     * @return true if successful
+     */
+    actual fun compareAndSet(expected: Int, new: Int): Boolean =
+        atomicInt.compareAndSet(expected, new)
+
+    /** Increments value by one. */
+    actual fun increment() {
+        atomicInt.incrementAndGet()
+    }
+
+    /** Decrements value by one. */
+    actual fun decrement() {
+        atomicInt.decrementAndGet()
+    }
+}

--- a/src/jvmMain/kotlin/org/kbson/ext/getCurrentTime.kt
+++ b/src/jvmMain/kotlin/org/kbson/ext/getCurrentTime.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+actual fun getCurrentTimeInMillis(): Long = System.currentTimeMillis()
+
+actual fun getCurrentTimeInSeconds(): Int = (getCurrentTimeInMillis() / 1000).toInt()

--- a/src/jvmTest/kotlin/org/kbson/BsonValueApiTest.kt
+++ b/src/jvmTest/kotlin/org/kbson/BsonValueApiTest.kt
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson
+
+import java.lang.reflect.Constructor
+import java.util.*
+import kotlin.jvm.internal.DefaultConstructorMarker
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class BsonValueApiTest {
+
+    @Test
+    fun bsonArrayTest() {
+        val bsonClass = org.bson.BsonArray::class.java
+        val kBsonClass = BsonArray::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass, listOf("parse", "toJson", "asBsonReader"))
+        val kBsonMethods = getMethodNames(kBsonClass, listOf("getSize"))
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonBinaryTest() {
+        val bsonClass = org.bson.BsonBinary::class.java
+        val kBsonClass = BsonBinary::class.java
+
+        val bsonConstructors =
+            getConstructorParams(bsonClass) { c -> c.parameterTypes.contains(UUID::class.java) }
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass, listOf("asUuid"))
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonBooleanTest() {
+        val bsonClass = org.bson.BsonBoolean::class.java
+        val kBsonClass = BsonBoolean::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonDateTimeTest() {
+        val bsonClass = org.bson.BsonDateTime::class.java
+        val kBsonClass = BsonDateTime::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass) { it.parameterTypes.isEmpty() }
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonDbPointerTest() {
+        val bsonClass = org.bson.BsonDbPointer::class.java
+        val kBsonClass = BsonDbPointer::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        bsonConstructors.forEach { Collections.replaceAll(it, "ObjectId", "BsonObjectId") }
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonObjectIdTest() {
+        val bsonClass = org.bson.BsonObjectId::class.java
+        val kBsonClass = BsonObjectId::class.java
+
+        // Note: Constructors differ as no ObjectId underlying class so not asserting.
+
+        val bsonMethods = getMethodNames(bsonClass, listOf("getValue"))
+        val kBsonMethods =
+            getMethodNames(
+                kBsonClass,
+                listOf(
+                    "toHexString",
+                    "toByteArray",
+                    "getTimestamp",
+                    "getRandomValue1",
+                    "getRandomValue2",
+                    "getCounter"))
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonDecimal128Test() {
+        val bsonClass = org.bson.BsonDecimal128::class.java
+        val kBsonClass = BsonDecimal128::class.java
+
+        // Note: Constructors differ as no Decimal128 underlying class or BigDecimal so not
+        // asserting.
+
+        val bsonMethods =
+            getMethodNames(
+                bsonClass,
+                listOf("intValue", "longValue", "doubleValue", "getValue", "decimal128Value"))
+        val kBsonMethods =
+            getMethodNames(
+                kBsonClass,
+                listOf("isNaN", "isInfinite", "isFinite", "isNegative", "getHigh", "getLow"))
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonDocumentTest() {
+        val bsonClass = org.bson.BsonDocument::class.java
+        val kBsonClass = BsonDocument::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors =
+            getConstructorParams(kBsonClass) { c ->
+                c.parameterTypes.contains(Map::class.java) ||
+                    c.parameterTypes.map { p -> p.componentType }.contains(Pair::class.java)
+            }
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods =
+            getMethodNames(
+                bsonClass,
+                listOf(
+                    "parse",
+                    "toJson",
+                    "toBsonDocument",
+                    "asBsonReader",
+                    "readObject",
+                    "writeReplace"))
+        val kBsonMethods =
+            getMethodNames(kBsonClass, listOf("getSize", "getEntries", "getKeys", "getValues"))
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonDoubleTest() {
+        val bsonClass = org.bson.BsonDouble::class.java
+        val kBsonClass = BsonDouble::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass, listOf("decimal128Value"))
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonInt32Test() {
+        val bsonClass = org.bson.BsonInt32::class.java
+        val kBsonClass = BsonInt32::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass, listOf("decimal128Value"))
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonInt64Test() {
+        val bsonClass = org.bson.BsonInt64::class.java
+        val kBsonClass = BsonInt64::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass, listOf("decimal128Value"))
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonJavaScriptTest() {
+        val bsonClass = org.bson.BsonJavaScript::class.java
+        val kBsonClass = BsonJavaScript::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonJavaScriptWithScopeTest() {
+        val bsonClass = org.bson.BsonJavaScriptWithScope::class.java
+        val kBsonClass = BsonJavaScriptWithScope::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass, listOf("clone"))
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonMaxKeyTest() {
+        val bsonClass = org.bson.BsonMaxKey::class.java
+        val kBsonClass = BsonMaxKey::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonMinKeyTest() {
+        val bsonClass = org.bson.BsonMinKey::class.java
+        val kBsonClass = BsonMinKey::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonRegularExpressionTest() {
+        val bsonClass = org.bson.BsonRegularExpression::class.java
+        val kBsonClass = BsonRegularExpression::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonStringTest() {
+        val bsonClass = org.bson.BsonString::class.java
+        val kBsonClass = BsonString::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonSymbolTest() {
+        val bsonClass = org.bson.BsonSymbol::class.java
+        val kBsonClass = BsonSymbol::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonTimestamp() {
+        val bsonClass = org.bson.BsonTimestamp::class.java
+        val kBsonClass = BsonTimestamp::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    @Test
+    fun bsonUndefinedTest() {
+        val bsonClass = org.bson.BsonUndefined::class.java
+        val kBsonClass = BsonUndefined::class.java
+
+        val bsonConstructors = getConstructorParams(bsonClass)
+        val kBsonConstructors = getConstructorParams(kBsonClass)
+        assertEquals(bsonConstructors, kBsonConstructors)
+
+        val bsonMethods = getMethodNames(bsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass)
+        assertEquals(bsonMethods, kBsonMethods)
+    }
+
+    private fun getConstructorParams(
+        clazz: Class<*>,
+        exclusions: (Constructor<*>) -> Boolean = { false }
+    ): List<List<String>> {
+        return clazz.constructors
+            .filterNot { it.parameterTypes.contains(DefaultConstructorMarker::class.java) }
+            .filterNot { exclusions.invoke(it) }
+            .map { it.parameterTypes.map { p -> p.simpleName }.toList() }
+            .sortedBy { it.toString() }
+    }
+
+    private fun getMethodNames(clazz: Class<*>, exclusions: List<String> = listOf()): Set<String> {
+        val kotlinExtraBsonValueMethods = listOf("isMaxKey", "isMinKey", "isUndefined")
+        return clazz.methods
+            .map { it.name }
+            .filterNot {
+                it.startsWith("access\$get") ||
+                    exclusions.contains(it) ||
+                    kotlinExtraBsonValueMethods.contains(it)
+            }
+            .toSet()
+    }
+}

--- a/src/nativeMain/kotlin/org/kbson/ext/AtomicInt.kt
+++ b/src/nativeMain/kotlin/org/kbson/ext/AtomicInt.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+import kotlin.native.concurrent.AtomicInt
+
+/** A Kotlin native wrapper of atomic integer */
+actual class AtomicInt actual constructor(value: Int) {
+
+    val atomicInt: AtomicInt
+
+    init {
+        atomicInt = AtomicInt(value)
+    }
+
+    /** Gets the current value */
+    actual fun getValue(): Int = atomicInt.value
+
+    /**
+     * Increments the value by [delta] and returns the new value.
+     *
+     * @param delta the value to add
+     * @return the new value
+     */
+    actual fun addAndGet(delta: Int): Int = atomicInt.addAndGet(delta)
+
+    /**
+     * Compares value with [expected] and replaces it with [new] value if values matches.
+     *
+     * @param expected the expected value
+     * @param new the new value
+     * @return true if successful
+     */
+    actual fun compareAndSet(expected: Int, new: Int): Boolean =
+        atomicInt.compareAndSet(expected, new)
+
+    /** Increments value by one. */
+    actual fun increment() = atomicInt.increment()
+
+    /** Decrements value by one. */
+    actual fun decrement() = atomicInt.decrement()
+}

--- a/src/nativeMain/kotlin/org/kbson/ext/getCurrentTime.kt
+++ b/src/nativeMain/kotlin/org/kbson/ext/getCurrentTime.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kbson.ext
+
+import kotlin.system.getTimeMillis
+
+actual fun getCurrentTimeInMillis(): Long = getTimeMillis()
+
+actual fun getCurrentTimeInSeconds(): Int = (getCurrentTimeInMillis() / 1000).toInt()


### PR DESCRIPTION
Apologies for such a large review but this is the initial BsonValue conversion to multiplatform.

Things to note are:
  * Nested Bson types just store the core values: For example there is no ObjectId or Decimal128 type so BsonObjectId and BsonDecimal128 store the raw values.
  * There is no KMP (Kotlin Multi Platform) support for: BigDecimal - so BsonDecimal128 is simplified for now. Please add new tickets to the KBson project if further integration support is required.
  * There is no common AtomicInt or current time in ms classes, methods - required for BsonObjectId. So platform specific ways have been added.
  * Most tests are just common tests - meaning the run on JVM, JS and Native platforms.
  * There are Java specific API tests - that focus on API differences between the original BsonValues and this Kotlin port.
    * Main item to note is the lack of Kotlin Constructor support - In Kotlin primary and secondary constructors are supported but cannot contain much logic. So BsonObjectId utilizes companion object and invoke support for hexString and byteArray support.

KBSON-2